### PR TITLE
fix downloading in a tokio thread

### DIFF
--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,0 +1,10 @@
+use rusty_ytdl::*;
+
+#[tokio::main]
+async fn main() {
+    let video_url = "https://www.youtube.com/watch?v=FZ8BxMU3BYc";
+
+    let video = Video::new(video_url).unwrap();
+
+    println!("{:#?}", video.download().await.unwrap());
+}


### PR DESCRIPTION
When trying to download in a new ``tokio`` thread it gives this error:
```

    = help: within `tendril::tendril::NonAtomic`, the trait `Sync` is not implemented for `Cell<usize>`
note: future is not `Send` as this value is used across an await
   --> /home/salman/.cargo/registry/src/github.com-1ecc6299db9ec823/rusty_ytdl-0.4.1/src/info.rs:202:84
    |
133 |         let document = Html::parse_document(&response);
    |             -------- has type `scraper::html::Html` which is not `Send`
...
202 |                 get_functions(get_html5player(response.as_str()).unwrap(), &client).await?,
    |                                                                                    ^^^^^^ await occurs here, with `document` maybe used later
...
208 |     }
    |     - `document` is later dropped here
note: required by a bound in `tokio::spawn`
   --> /home/salman/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/task/spawn.rs:163:21
    |
163 |         T: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`

```

so the only thing needed was to put the parsed html document in a scope to make sure it drops properly, and satisfy the borrow checker

I also added an example for download :)

feel free to comment on anything