### PR TITLE
Fix typo in VideoSearchOptions

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -17,7 +17,7 @@ pub struct VideoInfo {
 #[derive(Clone, PartialEq, Debug, derive_more::Display)]
 pub enum VideoSearchOptions {
     #[display(fmt = "Video & Audio")]
-    VideoAuido,
+    VideoAudio,
     #[display(fmt = "Video")]
     Video,
     #[display(fmt = "Audio")]


### PR DESCRIPTION
Change `VideoSearchOptions::VideoAuido` to `VideoSearchOptions::VideoAudio`