### PR TITLE
Greatly improved performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+flamegraph.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,15 @@ unicode-segmentation = "1.11.0"
 boa_engine = "0.17.3"
 mime = "0.3.17"
 bytes = "1.5.0"
+flame = { version = "0.2.2", optional = true }
+flamer = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["full"] }
 
 [features]
 default = ["search", "live", "default-tls"]
+performance_analysis = ["flame", "flamer"]
 live = ["tokio/time", "tokio/process"]
 blocking = ["tokio/rt", "tokio/rt-multi-thread"]
 search = []
@@ -63,3 +66,7 @@ ffmpeg = ["tokio/process"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]
+
+[[example]]
+name = "multiple_downloads"
+required-features = ["performance_analysis"]

--- a/cli/src/args/log.rs
+++ b/cli/src/args/log.rs
@@ -12,7 +12,7 @@ pub struct LogArgs {
     /// (-v = Error, ..., -vvvvv = Trace)
     /// (other crates have log level Warn)
     #[clap(
-        long, 
+        long,
         short,
         action = clap::ArgAction::Count,
         global = true,

--- a/cli/src/args/video_options.rs
+++ b/cli/src/args/video_options.rs
@@ -1,25 +1,25 @@
 use clap::Parser;
-use serde::{Deserialize, Serialize};
 use rusty_ytdl::VideoQuality;
+use serde::{Deserialize, Serialize};
 
 #[derive(Parser)]
 pub struct VideoOptionsArgs {
     /// Pick a Stream, that contains only video track
     #[clap(
-        long, 
+        long,
         conflicts_with_all(& ["only_audio"])
     )]
     pub only_video: bool,
 
     /// Pick a Stream, that contains only audio track
     #[clap(
-        long, 
+        long,
         conflicts_with_all(& ["only_video"])
     )]
     pub only_audio: bool,
 
     /// Download the stream with this quality
-    /// 
+    ///
     /// [possible_values: highest, lowest, highest_audio, lowest_audio, highest_video, lowest_video]
     #[clap(
     long,

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -1,2 +1,1 @@
 pub mod result_serializer;
-

--- a/examples/multiple_downloads.rs
+++ b/examples/multiple_downloads.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+
 use rusty_ytdl::*;
 
 #[tokio::main]
@@ -20,4 +22,5 @@ async fn main() {
         println!("Downloading: {}", info.video_details.title);
     }
     println!("Time taken: {:?}", instant.elapsed());
+    flame::dump_html(File::create("flamegraph.html").unwrap()).unwrap();
 }

--- a/examples/multiple_downloads.rs
+++ b/examples/multiple_downloads.rs
@@ -1,0 +1,23 @@
+use rusty_ytdl::*;
+
+#[tokio::main]
+async fn main() {
+    let urls = [
+        "https://youtube.com/watch?v=Rbgw_rduQpM",
+        "https://youtube.com/watch?v=-h6PCkfTBcc",
+        "https://youtube.com/watch?v=2SUwOgmvzK4",
+        "https://youtube.com/watch?v=9Ueulv6BugQ",
+        "https://youtube.com/watch?v=R4hDcd9fzRk",
+        "https://youtube.com/watch?v=W5Sq71VTJ9Q",
+    ];
+
+    let instant = std::time::Instant::now();
+    for url in urls {
+        let video = Video::new(url).unwrap();
+
+        let info = video.get_info().await.unwrap();
+
+        println!("Downloading: {}", info.video_details.title);
+    }
+    println!("Time taken: {:?}", instant.elapsed());
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -35,6 +35,7 @@ pub struct Video {
 
 impl Video {
     /// Crate [`Video`] struct to get info or download with default [`VideoOptions`]
+    #[cfg_attr(feature = "performance_analysis", flamer::flame)]
     pub fn new(url_or_id: impl Into<String>) -> Result<Self, VideoError> {
         let video_id = get_video_id(&url_or_id.into()).ok_or(VideoError::VideoNotFound)?;
 
@@ -112,6 +113,7 @@ impl Video {
 
     /// Try to get basic information about video
     /// - `HLS` and `DashMPD` formats excluded!
+    #[cfg_attr(feature = "performance_analysis", flamer::flame)]
     pub async fn get_basic_info(&self) -> Result<VideoInfo, VideoError> {
         let client = &self.client;
 
@@ -195,18 +197,21 @@ impl Video {
         Ok(VideoInfo {
             dash_manifest_url,
             hls_manifest_url,
-            formats: parse_video_formats(
-                &player_response,
-                get_functions(get_html5player(response.as_str()).unwrap(), client).await?,
-            )
-            .unwrap_or_default(),
-            related_videos: get_related_videos(&initial_response).unwrap_or_default(),
+            formats: {
+                parse_video_formats(
+                    &player_response,
+                    get_functions(get_html5player(response.as_str()).unwrap(), client).await?,
+                )
+                .unwrap_or_default()
+            },
+            related_videos: { get_related_videos(&initial_response).unwrap_or_default() },
             video_details,
         })
     }
 
     /// Try to get full information about video
     /// - `HLS` and `DashMPD` formats included!
+    #[cfg_attr(feature = "performance_analysis", flamer::flame)]
     pub async fn get_info(&self) -> Result<VideoInfo, VideoError> {
         let client = &self.client;
 

--- a/src/info_extras.rs
+++ b/src/info_extras.rs
@@ -119,9 +119,17 @@ pub fn parse_related_video(
         "0".to_string()
     };
 
-    let regex = Regex::new(r"^\d").unwrap();
+    // This regex is not useful
+    // let regex = Regex::new(r"^\d").unwrap();
+    let first = |string: &str| {
+        string
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+    };
 
-    if !regex.is_match(&short_view_count) {
+    if !first(&short_view_count) {
         let rvs_details_index = rvs_params
             .iter()
             .map(|x| serde_qs::from_str::<QueryParams>(x).unwrap())
@@ -139,7 +147,7 @@ pub fn parse_related_video(
         }
     }
 
-    view_count = if regex.is_match(view_count) {
+    view_count = if first(view_count) {
         view_count
             .split(' ')
             .collect::<Vec<&str>>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,12 @@
 #![allow(unused_imports)]
 #![allow(clippy::type_complexity)]
 
+#[cfg(feature = "performance_analysis")]
+pub extern crate flame;
+#[cfg(feature = "performance_analysis")]
+#[macro_use] extern crate flamer;
+
+
 mod info;
 mod info_extras;
 mod structs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 #[cfg(feature = "performance_analysis")]
 pub extern crate flame;
 #[cfg(feature = "performance_analysis")]
-#[macro_use] extern crate flamer;
-
+#[macro_use]
+extern crate flamer;
 
 mod info;
 mod info_extras;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
-use boa_engine::Context;
+use boa_engine::optimizer::OptimizerOptions;
+use boa_engine::{Context, JsValue, Source};
 use bytes::Bytes;
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -627,26 +628,35 @@ pub fn set_download_url(
         if let Some(&result) = n_transfrom_cache.get(n_transform_value).as_ref() {
             n_transform_result = result.clone();
         } else {
-            let mut context = boa_engine::Context::default();
-            let n_transform_script = context.eval(boa_engine::Source::from_bytes(
-                n_transform_script_string.1.as_str(),
-            ));
-
-            if n_transform_script.is_err() {
-                return url.to_string();
+            #[cfg_attr(feature = "performance_analysis", flamer::flame)]
+            // Caching this would be great (~2ms x 2 gain/req on Ryzen 9 5950XT) but is quite hard because of the !Send nature of boa
+            fn create_transform_script(script: &str) -> Context<'_> {
+                let mut context = boa_engine::Context::default();
+                context.eval(parse_source(
+                    script,
+                )).unwrap();
+                context
             }
 
-            let result = context.eval(boa_engine::Source::from_bytes(&format!(
-                r#"{func_name}("{args}")"#,
-                func_name = n_transform_script_string.0.as_str(),
-                args = n_transform_value
-            )));
-
-            if result.is_err() {
-                return url.to_string();
+            #[cfg_attr(feature = "performance_analysis", flamer::flame)]
+            fn parse_source<'a>(script: &'a str) -> Source<&'a [u8]> {
+                boa_engine::Source::from_bytes(script)
             }
 
-            let is_result_string = result.as_ref().unwrap().as_string();
+            #[cfg_attr(feature = "performance_analysis", flamer::flame)]
+            // Optimizing the script would be great (~20ms x 2 gain/req on Ryzen 9 5950XT) but quite some work on boa side
+            // This is where most of the time is spent
+            fn execute_transform_script(context: &mut Context, func_name: &str, n_transform_value: &str) -> JsValue{
+                context.eval(parse_source(&format!(
+                    r#"{func_name}("{n_transform_value}")"#,
+                ))).unwrap()
+            }
+
+            let mut context = create_transform_script(n_transform_script_string.1.as_str());
+
+            let is_result_string = execute_transform_script(&mut context, n_transform_script_string.0.as_str(), n_transform_value);
+
+            let is_result_string = is_result_string.as_string();
 
             if is_result_string.is_none() {
                 return url.to_string();

--- a/tests/get_info.rs
+++ b/tests/get_info.rs
@@ -1,5 +1,3 @@
-use rusty_ytdl;
-
 #[tokio::test]
 async fn get_info() {
     use rusty_ytdl::Video;

--- a/tests/get_info_with_options.rs
+++ b/tests/get_info_with_options.rs
@@ -1,5 +1,3 @@
-use rusty_ytdl;
-
 #[tokio::test]
 async fn get_info_with_options() {
     use rusty_ytdl::{choose_format, Video, VideoOptions, VideoQuality, VideoSearchOptions};

--- a/tests/regex.rs
+++ b/tests/regex.rs
@@ -1,5 +1,3 @@
-use rusty_ytdl;
-
 #[tokio::test]
 async fn is_valid_id_or_link() {
     use rusty_ytdl::get_video_id;

--- a/tests/static_formats.rs
+++ b/tests/static_formats.rs
@@ -1,5 +1,3 @@
-use rusty_ytdl;
-
 #[tokio::test]
 async fn formats_str_to_json() {
     use rusty_ytdl::constants::FORMATS;


### PR DESCRIPTION
I took most of the low hanging fruits:
 ~ +5-15% on caching
 ~ +5-10% on parsing
Plus some general improvements to performance that maybe all had up to 1% but I wasn't able to test it because of the network variability.

On my computer (Ryzen 7950XT):
 - Before the optimizations: 4.2s (+- 0.3s)
 - After the optimizations: 3.1s (+- 0.2s)
Note that the benchmark has been made averaging 12 sample runs.
Here is the run command for reproducibility: `cargo run --release --example multiple_downloads --features=performance_analysis`

A new performance analysis mode has been added, enabling the use of flamegraphs.

Note that most of the improvements are on CPU bound tasks. On lower end CPUs the improvement would probably be a lot more since I'm mostly network bound.

I also added comments on my change to explain how much each one improved performance.
I noticed also that the code could be simplified by quite a margin, I do a followup PR on code aesthetics and quality.
