### PR TITLE
fix(examples/download_to_file): change .mp3 to .mp4

### DIFF
--- a/examples/download_to_file.rs
+++ b/examples/download_to_file.rs
@@ -6,7 +6,7 @@ async fn main() {
 
     let video = Video::new(url).unwrap();
 
-    let path = std::path::Path::new(r"test.mp3");
+    let path = std::path::Path::new(r"test.mp4");
 
     video.download(path).await.unwrap();
 }


### PR DESCRIPTION
When I ran the original code from `download_to_file.rs`, the downloaded mp3 files didn't work. But when I change the `.mp3` to `mp4`, it works.