### PR TITLE
Make max retries configurable

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1234,3 +1234,6 @@ pub static FORMATS: Lazy<HashMap<&str, StaticFormat>> = Lazy::new(|| {
         ),
     ])
 });
+
+/// Default number of retries for a web reqwest.
+pub const DEFAULT_RETRIES: u32 = 3;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1235,5 +1235,5 @@ pub static FORMATS: Lazy<HashMap<&str, StaticFormat>> = Lazy::new(|| {
     ])
 });
 
-/// Default number of retries for a web reqwest.
-pub const DEFAULT_RETRIES: u32 = 3;
+/// Default max number of retries for a web reqwest.
+pub const DEFAULT_MAX_RETRIES: u32 = 3;

--- a/src/info.rs
+++ b/src/info.rs
@@ -102,7 +102,7 @@ impl Video {
             }
         };
 
-        let max_retries = options.request_options.override_max_retries.unwrap_or(DEFAULT_MAX_RETRIES);
+        let max_retries = options.request_options.max_retries.unwrap_or(DEFAULT_MAX_RETRIES);
 
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(Duration::from_millis(1000), Duration::from_millis(30000))

--- a/src/info.rs
+++ b/src/info.rs
@@ -15,7 +15,7 @@ use crate::stream::{LiveStream, LiveStreamOptions};
 use crate::structs::FFmpegArgs;
 
 use crate::{
-    constants::{BASE_URL, DEFAULT_RETRIES},
+    constants::{BASE_URL, DEFAULT_MAX_RETRIES},
     info_extras::{get_media, get_related_videos},
     stream::{NonLiveStream, NonLiveStreamOptions, Stream},
     structs::{
@@ -52,7 +52,7 @@ impl Video {
 
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(Duration::from_millis(1000), Duration::from_millis(30000))
-            .build_with_max_retries(DEFAULT_RETRIES);
+            .build_with_max_retries(DEFAULT_MAX_RETRIES);
         let client = ClientBuilder::new(client)
             .with(RetryTransientMiddleware::new_with_policy_and_strategy(
                 retry_policy,
@@ -102,7 +102,7 @@ impl Video {
             }
         };
 
-        let max_retries = options.request_options.override_max_retries.unwrap_or(DEFAULT_RETRIES);
+        let max_retries = options.request_options.override_max_retries.unwrap_or(DEFAULT_MAX_RETRIES);
 
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(Duration::from_millis(1000), Duration::from_millis(30000))

--- a/src/info.rs
+++ b/src/info.rs
@@ -15,7 +15,7 @@ use crate::stream::{LiveStream, LiveStreamOptions};
 use crate::structs::FFmpegArgs;
 
 use crate::{
-    constants::BASE_URL,
+    constants::{BASE_URL, DEFAULT_RETRIES},
     info_extras::{get_media, get_related_videos},
     stream::{NonLiveStream, NonLiveStreamOptions, Stream},
     structs::{
@@ -52,7 +52,7 @@ impl Video {
 
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(Duration::from_millis(1000), Duration::from_millis(30000))
-            .build_with_max_retries(3);
+            .build_with_max_retries(DEFAULT_RETRIES);
         let client = ClientBuilder::new(client)
             .with(RetryTransientMiddleware::new_with_policy_and_strategy(
                 retry_policy,
@@ -102,9 +102,11 @@ impl Video {
             }
         };
 
+        let max_retries = options.request_options.override_max_retries.unwrap_or(DEFAULT_RETRIES);
+
         let retry_policy = ExponentialBackoff::builder()
             .retry_bounds(Duration::from_millis(1000), Duration::from_millis(30000))
-            .build_with_max_retries(3);
+            .build_with_max_retries(max_retries);
         let client = ClientBuilder::new(client)
             .with(RetryTransientMiddleware::new_with_policy_and_strategy(
                 retry_policy,

--- a/src/stream/streams/live.rs
+++ b/src/stream/streams/live.rs
@@ -1,4 +1,4 @@
-use crate::constants::DEFAULT_HEADERS;
+use crate::constants::{DEFAULT_HEADERS, DEFAULT_RETRIES};
 use crate::stream::{
     encryption::Encryption, media_format::MediaFormat, remote_data::RemoteData, segment::Segment,
     streams::Stream,
@@ -41,7 +41,7 @@ impl LiveStream {
                     std::time::Duration::from_millis(1000),
                     std::time::Duration::from_millis(30000),
                 )
-                .build_with_max_retries(3);
+                .build_with_max_retries(DEFAULT_RETRIES);
             reqwest_middleware::ClientBuilder::new(client)
                 .with(
                     reqwest_retry::RetryTransientMiddleware::new_with_policy_and_strategy(

--- a/src/stream/streams/live.rs
+++ b/src/stream/streams/live.rs
@@ -1,4 +1,4 @@
-use crate::constants::{DEFAULT_HEADERS, DEFAULT_RETRIES};
+use crate::constants::{DEFAULT_HEADERS, DEFAULT_MAX_RETRIES};
 use crate::stream::{
     encryption::Encryption, media_format::MediaFormat, remote_data::RemoteData, segment::Segment,
     streams::Stream,
@@ -41,7 +41,7 @@ impl LiveStream {
                     std::time::Duration::from_millis(1000),
                     std::time::Duration::from_millis(30000),
                 )
-                .build_with_max_retries(DEFAULT_RETRIES);
+                .build_with_max_retries(DEFAULT_MAX_RETRIES);
             reqwest_middleware::ClientBuilder::new(client)
                 .with(
                     reqwest_retry::RetryTransientMiddleware::new_with_policy_and_strategy(

--- a/src/stream/streams/non_live.rs
+++ b/src/stream/streams/non_live.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
-use crate::constants::{DEFAULT_HEADERS, DEFAULT_RETRIES};
+use crate::constants::{DEFAULT_HEADERS, DEFAULT_MAX_RETRIES};
 use crate::stream::streams::Stream;
 use crate::structs::{CustomRetryableStrategy, VideoError};
 
@@ -62,7 +62,7 @@ impl NonLiveStream {
                     std::time::Duration::from_millis(1000),
                     std::time::Duration::from_millis(30000),
                 )
-                .build_with_max_retries(DEFAULT_RETRIES);
+                .build_with_max_retries(DEFAULT_MAX_RETRIES);
             reqwest_middleware::ClientBuilder::new(client)
                 .with(
                     reqwest_retry::RetryTransientMiddleware::new_with_policy_and_strategy(

--- a/src/stream/streams/non_live.rs
+++ b/src/stream/streams/non_live.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
-use crate::constants::DEFAULT_HEADERS;
+use crate::constants::{DEFAULT_HEADERS, DEFAULT_RETRIES};
 use crate::stream::streams::Stream;
 use crate::structs::{CustomRetryableStrategy, VideoError};
 
@@ -62,7 +62,7 @@ impl NonLiveStream {
                     std::time::Duration::from_millis(1000),
                     std::time::Duration::from_millis(30000),
                 )
-                .build_with_max_retries(3);
+                .build_with_max_retries(DEFAULT_RETRIES);
             reqwest_middleware::ClientBuilder::new(client)
                 .with(
                     reqwest_retry::RetryTransientMiddleware::new_with_policy_and_strategy(

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -226,7 +226,7 @@ pub struct RequestOptions {
     ///     // Allow 5 retries per chunk.
     ///     let video_options = VideoOptions {
     ///          request_options: RequestOptions {
-    ///               override_max_retries: Some(5),
+    ///               max_retries: Some(5),
     ///                ..Default::default()
     ///          },
     ///          ..Default::default()

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -219,7 +219,7 @@ pub struct RequestOptions {
     /// ```
     pub ipv6_block: Option<String>,
     /// Override the default number of retries to allow per web request (ie, per chunk downloaded)
-    /// Default is [`crate::constants::DEFAULT_RETRIES`].
+    /// Default is [`crate::constants::DEFAULT_MAX_RETRIES`].
     ///
     /// # Example
     /// ```ignore

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -232,7 +232,7 @@ pub struct RequestOptions {
     ///          ..Default::default()
     ///     };
     /// ```
-    pub override_max_retries: Option<u32>,
+    pub max_retries: Option<u32>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -218,6 +218,21 @@ pub struct RequestOptions {
     ///     };
     /// ```
     pub ipv6_block: Option<String>,
+    /// Override the default number of retries to allow per web request (ie, per chunk downloaded)
+    /// Default is [`crate::constants::DEFAULT_RETRIES`].
+    ///
+    /// # Example
+    /// ```ignore
+    ///     // Allow 5 retries per chunk.
+    ///     let video_options = VideoOptions {
+    ///          request_options: RequestOptions {
+    ///               override_max_retries: Some(5),
+    ///                ..Default::default()
+    ///          },
+    ///          ..Default::default()
+    ///     };
+    /// ```
+    pub override_max_retries: Option<u32>,
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
Perhaps more unlikely with the new changes from 3.8.24, but it could be still possible for chunk max retries to be insufficient. This PR allows library consumers to override the default number of retries. Used an Option in RequestOptions to work in with the `derive(Default)`.

IMO - resolves #32.