### PR TITLE
Allow passing VideoOptions by value or by reference to `new_with_options` - Closes #38

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -4,6 +4,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     fmt::{Debug, Formatter, Result as fmtResult},
     ops::{Bound, RangeBounds},
@@ -146,6 +147,18 @@ impl Default for VideoOptions {
             download_options: DownloadOptions::default(),
             request_options: RequestOptions::default(),
         }
+    }
+}
+
+impl<'opts> From<&'opts VideoOptions> for Cow<'opts, VideoOptions> {
+    fn from(value: &'opts VideoOptions) -> Self {
+        Cow::Borrowed(value)
+    }
+}
+
+impl From<VideoOptions> for Cow<'static, VideoOptions> {
+    fn from(value: VideoOptions) -> Self {
+        Cow::Owned(value)
     }
 }
 


### PR DESCRIPTION
Follow on from issue #38.

This took a little more work than I was expecting, as I missed that `Video` stores `VideoOptions`, therefore we need a new lifetime parameter on Video to make this work. Unfortunately this is a breaking change for anyone storing a `Video` in a struct (not sure why you would), but I was able to avoid the main one (users passing VideoOptions by value) by relaxing the type signature of `Video::new_with_options()`.

I also removed a redundant clone on the `Video::get_options()` method, needed to be touched anyway for this change.