### PR TITLE
Add ability to supply own PO tokens

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -52,8 +52,6 @@ pub(crate) const DEFAULT_DL_CHUNK_SIZE: u64 = 10485760;
 /// Default max number of retries for a web reqwest.
 pub(crate) const DEFAULT_MAX_RETRIES: u32 = 3;
 
-pub(crate) const POTOKEN_EXPERIMENTS: &[&str] = &["51217476", "51217102"];
-
 pub static INNERTUBE_CLIENT: Lazy<HashMap<&str, (&str, &str, &str)>> =
     // (clientVersion, clientName, json value)
     Lazy::new(|| {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -248,6 +248,9 @@ pub struct RequestOptions {
     ///     };
     /// ```
     pub max_retries: Option<u32>,
+    /// Supply a YouTube Proof of Origin token. Use at your own risk.
+    /// See https://github.com/yt-dlp/yt-dlp/wiki/Extractors#po-token-guide for more information.
+    pub po_token: Option<String>,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ use urlencoding::decode;
 use crate::{
     constants::{
         AGE_RESTRICTED_URLS, AUDIO_ENCODING_RANKS, BASE_URL, FORMATS, IPV6_REGEX, PARSE_INT_REGEX,
-        POTOKEN_EXPERIMENTS, VALID_QUERY_DOMAINS, VIDEO_ENCODING_RANKS,
+        VALID_QUERY_DOMAINS, VIDEO_ENCODING_RANKS,
     },
     info_extras::{get_author, get_chapters, get_dislikes, get_likes, get_storyboards},
     structs::{
@@ -994,29 +994,6 @@ pub fn get_ytconfig(html: &str) -> Result<YTConfig, VideoError> {
         ),
         None => Err(VideoError::VideoSourceNotFound),
     }
-}
-
-pub fn check_experiments(html: &str) -> bool {
-    if let Some(configs) = get_ytconfig(html)
-        .ok()
-        .and_then(|x| x.web_player_context_configs.clone())
-        .and_then(|v| v.as_object().cloned())
-    {
-        return configs.iter().any(|(_, config)| {
-            config
-                .get("serializedExperimentIds")
-                .and_then(|v| v.as_str())
-                .map(|ids| {
-                    let ids_set = ids.split(',').collect::<Vec<&str>>();
-                    POTOKEN_EXPERIMENTS
-                        .iter()
-                        .any(|token| ids_set.contains(token))
-                })
-                .unwrap_or(false)
-        });
-    }
-
-    false
 }
 
 type CacheFunctions = Lazy<RwLock<Option<(String, Vec<(String, String)>)>>>;


### PR DESCRIPTION
This partially resolves #43.
Added new request_option to supply PO token. I have tested this with a PO token from my browser and confirmed that this resolves #44 when a correct token is supplied.

In a future PR I'd like to add the ability to supply own visitor data as well, but that will require a little more refactoring. @clytras it seems the PO token by itself is sufficient - if possible could you please explain why we might need visitor data as well?