### PR TITLE
chore: Update boa_engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ async-trait = "0.1.81"
 aes = "0.8.4"
 cbc = { version = "0.1.2", features = ["std"] }
 hex = "0.4.3"
-boa_engine = "0.19.0"
+boa_engine = "0.20.0"
 mime = "0.3.17"
 bytes = "1.7.1"
 flame = { version = "0.2.2", optional = true }


### PR DESCRIPTION
This PR updates boa_engine to v0.20.0, which resolves a security concern (details: https://github.com/boa-dev/boa/issues/4033).

Have tested this locally and no regressions noted.