### PR TITLE
fix: consider 'X-Goog-Visitor-Id' and download works now

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -23,10 +23,7 @@ use crate::{
         CustomRetryableStrategy, PlayerResponse, VideoError, VideoInfo, VideoOptions, YTConfig,
     },
     utils::{
-        between, choose_format, clean_video_details, get_functions, get_html,
-        get_html5player, get_random_v6_ip, get_video_id, get_ytconfig, is_age_restricted_from_html,
-        is_live, is_not_yet_broadcasted, is_play_error, is_player_response_error, is_private_video,
-        is_rental, parse_live_video_formats, parse_video_formats, sort_formats,
+        between, choose_format, clean_video_details, get_functions, get_html, get_html5player, get_random_v6_ip, get_video_id, get_visitor_data, get_ytconfig, is_age_restricted_from_html, is_live, is_not_yet_broadcasted, is_play_error, is_player_response_error, is_private_video, is_rental, parse_live_video_formats, parse_video_formats, sort_formats
     },
 };
 
@@ -534,6 +531,8 @@ impl<'opts> Video<'opts> {
         let sts = ytcfg.sts.unwrap_or(0);
         let video_id = self.get_video_id();
 
+        let visitor_data = get_visitor_data(&html)?;
+
         let mut query = serde_json::from_str::<serde_json::Value>(&format!(
             r#"{{
             {client}
@@ -577,6 +576,10 @@ impl<'opts> Video<'opts> {
         headers.insert(
             HeaderName::from_str("X-Youtube-Client-Name").unwrap(),
             HeaderValue::from_str(configs.1).unwrap(),
+        );
+        headers.insert(
+            HeaderName::from_str("X-Goog-Visitor-Id").unwrap(),
+            HeaderValue::from_str(&visitor_data).unwrap()
         );
 
         let response = self

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -996,6 +996,15 @@ pub fn get_ytconfig(html: &str) -> Result<YTConfig, VideoError> {
     }
 }
 
+pub fn get_visitor_data(html: &str) -> Result<String, VideoError> {
+    static PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r#""visitorData":"([^"]+)""#).unwrap());
+
+    match PATTERN.captures(html) {
+        Some(c) => Ok(c.get(1).map_or("", |m| m.as_str()).to_string()),
+        None => Err(VideoError::VideoSourceNotFound),
+    }
+}
+
 type CacheFunctions = Lazy<RwLock<Option<(String, Vec<(String, String)>)>>>;
 static FUNCTIONS: CacheFunctions = Lazy::new(|| RwLock::new(None));
 


### PR DESCRIPTION
Closes #49 

the base idea is taken from: https://github.com/distubejs/ytdl-core/commit/69fb0099352ba62fc370d20b5ef7ca1ae04cbaaa