### PR TITLE
chore: Update reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [".", "cli"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.12.5", features = [
+reqwest = { version = "0.13.1", features = [
     "cookies",
     "gzip",
 ], default-features = false }
@@ -39,8 +39,8 @@ derivative = "2.2.0"
 once_cell = "1.19.0"
 tokio = { version = "1.39.2", default-features = false, features = ["sync"] }
 rand = "0.8.5"
-reqwest-middleware = { version = "0.3.3", features = ["json"] }
-reqwest-retry = "0.6.1"
+reqwest-middleware = { version = "0.5.0", features = ["json", "query"] }
+reqwest-retry = "0.9.0"
 m3u8-rs = "6.0.0"
 async-trait = "0.1.81"
 aes = "0.8.4"
@@ -64,7 +64,7 @@ search = []
 ffmpeg = ["tokio/process", "tokio/io-util"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls = ["reqwest/rustls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
 socks = ["reqwest/socks"]
 


### PR DESCRIPTION
PR updates reqwest to latest version and repairs breaking changes.

Note, this is a possible breaking change to consumers of rusty_ytdl, as request v0.13 changed to rustls by default, and I suggest we do the same here. 
The alternative is to, override the default, but it puts the maintenance burden on this crate.